### PR TITLE
Fix read index and wrong path variable in file IO

### DIFF
--- a/eval/get_visual_case.py
+++ b/eval/get_visual_case.py
@@ -38,7 +38,7 @@ def load_drop_positions(dp_jsonl_path):
     with open(dp_jsonl_path, 'r') as f:
         lines = f.readlines()
     
-    data = json.loads(lines[0])
+    data = json.loads(lines[-1])
     if isinstance(data, list):
         dp = data[0]
     else:

--- a/eval/qwen2_5_vl/modeling_qwen2_5_vl_DTD.py
+++ b/eval/qwen2_5_vl/modeling_qwen2_5_vl_DTD.py
@@ -1394,7 +1394,7 @@ class Qwen2_5_VLModel(Qwen2_5_VLPreTrainedModel):
         
         # save drop positions info
         if dp_save_path:
-            with open(dp_save_path, 'a' if os.path.exists(dr_save_path) else 'w') as f:
+            with open(dp_save_path, 'a' if os.path.exists(dp_save_path) else 'w') as f:
                 f.write(json.dumps(dropped_positions_info) + '\n')
 
         return dropped_hidden_states, dropped_position_embeddings, dropped_pos_ids


### PR DESCRIPTION
Fix #33 

- Fixed reading from `lines[0]` to `lines[-1]` for append mode to visualize the most recent dropped tokens
- Fixed wrong variable in path existence check `dr_save_path` -> `dp_save_path`